### PR TITLE
Add a new HH transformation kernel that is more performant for large `nev`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-[[
+#[[
  * The MIT License (MIT)
  *
  * Copyright (c) 2019 Victor Yu
@@ -21,7 +21,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ]]
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(hh_test VERSION 0.0.1 LANGUAGES Fortran CUDA)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,27 @@
-cmake_minimum_required(VERSION 3.8)
+[[
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Victor Yu
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+]]
+
+cmake_minimum_required(VERSION 3.5)
 
 project(hh_test VERSION 0.0.1 LANGUAGES Fortran CUDA)
 
@@ -11,3 +34,5 @@ add_executable(hh_test
 
 set_target_properties(hh_test PROPERTIES LINKER_LANGUAGE Fortran)
 set_target_properties(hh_test PROPERTIES Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/include)
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -arch=sm_80 -lineinfo -g --ptxas-options=-v")
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2019 Victor Yu
+Copyright (c) 2020 NVIDIA CORPORATION
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/compute_hh.cu
+++ b/src/compute_hh.cu
@@ -1,6 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Victor Yu
+ * Copyright (c) 2020 NVIDIA CORPORATION
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include "cuda_runtime.h"
+#include <cub/cub.cuh>
 
 // Try CUDA 11 warp reduce
 
@@ -214,6 +239,169 @@ __global__ void compute_hh_trafo_kernel_real(T * __restrict__ q, const T * __res
     }
 }
 
+#define USE_MMA // On Ampere the double precision tensor cores (DMMA) are available
+
+#ifdef USE_MMA
+#include "mma_m8n8k4_fp64_sm80.cuh"
+#else
+
+template<int bK, int bN>
+__device__ inline int shared_memory_offset(int k, int n) {
+  // Shared memory layout for non-MMA version.
+  return k * bN + n;
+}
+
+__device__ inline constexpr int shared_memory_bytes(int bK, int bN) {
+  // Shared memory size for the bM by bK matrix. Version for the non-MMA.
+  return bN * bK;
+}
+
+#endif
+
+/*
+Householder transformation
+
+This is based the on the original warp sync version shown above.
+
+(I - tau * hh * hh^T) * q = q - tau * hh * hh^T * q
+
+Name here : Name in paper
+q         : X
+hh        : v
+hh_tau    : tau
+nev       : N_C
+nb        : nbw (==b)
+ncols     : N_R (==n+b-1)
+*/
+template <typename T, int bM, int bN, int block_y, int block_z>
+__global__ void compute_hh_trafo_gpu(T * __restrict__ q, const T * __restrict__ hh, const T * __restrict__ hh_tau, const int nev, const int nb, const int ldq, const int ncols)
+{
+  constexpr int bK = bM;
+
+  extern __shared__ int smem[];
+
+  T *hh_s = reinterpret_cast<T *>(smem);
+  T *q_s = &hh_s[bM];
+  T *hh_tau_s = &q_s[shared_memory_bytes(bK, bN)];
+#ifdef USE_MMA
+  T *sum_s = &hh_tau_s[1]; // Shared memory buffer if we perform the inner product with DMMA.
+#endif
+
+  int j = ncols;
+
+  int bid = blockIdx.y * bN; // n-index offset for this block.
+
+  for (int k = threadIdx.z; k < bK; k += block_z) {
+    for (int n = threadIdx.y; n < bN; n += block_y) {
+      q_s[shared_memory_offset<bK, bN>(k, n)] = (n + bid) < nev ? q[(j + k - 1) * ldq + n + bid] : 0;
+    }
+  }
+
+  constexpr int thread_m_dim = bM / block_z;
+  constexpr int thread_n_dim = bN / block_y;
+
+  T reg[thread_n_dim * thread_m_dim];
+
+  while (j >= 1)
+  {
+    int hh_idx = threadIdx.z * blockDim.y + threadIdx.y;
+    if (hh_idx == 0) { *hh_tau_s = hh_tau[j - 1]; }
+    while (hh_idx < nb) {
+      hh_s[hh_idx] = hh[hh_idx + (j - 1) * nb];
+      hh_idx += blockDim.z * blockDim.y;
+    }
+
+    if (j < ncols && threadIdx.z == 0) {
+      for (int n = threadIdx.y; n < bN; n += block_y) {
+        q_s[shared_memory_offset<bK, bN>(0, n)] = (n + bid) < nev ? q[(j + 0 - 1) * ldq + n + bid] : 0;
+      }
+    }
+
+/**
+  If we use DMMA to perform the inner product, call the routine here and store results on the buffer.
+  If not, for each eigenvector, for each thread we calculate the `sum`.
+ */
+
+#ifdef USE_MMA
+    __syncthreads();
+    sum<bK, bN, block_z * block_y / 32>(hh_s, q_s, sum_s);
+    __syncthreads();
+#endif
+
+#pragma unroll
+    for (int n = 0; n < thread_n_dim; n++) {
+      int n_idx = threadIdx.y + n * block_y;
+
+#ifndef USE_MMA
+    T sum = 0;
+#pragma unroll 1
+    for (int k = 0; k < bK; k++) {
+      sum += hh_s[k] * q_s[shared_memory_offset<bK, bN>(k, n_idx)];
+    }
+#endif
+
+#pragma unroll
+      for (int m = 0; m < thread_m_dim; m++) {
+        int m_idx = threadIdx.z + m * block_z;
+#ifdef USE_MMA
+        reg[m * thread_n_dim + n] = q_s[shared_memory_offset<bK, bN>(m_idx, n_idx)] - *hh_tau_s * hh_s[m_idx] * sum_s[n_idx];
+#else
+        reg[m * thread_n_dim + n] = q_s[shared_memory_offset<bK, bN>(m_idx, n_idx)] - *hh_tau_s * hh_s[m_idx] * sum;
+#endif
+        if (j == 1 || m_idx == bM - 1) {
+          if (n_idx + bid < nev) { q[(m_idx + j - 1) * ldq + n_idx + bid] = reg[m * thread_n_dim + n]; }
+        }
+      }
+    }
+
+    __syncthreads();
+
+#pragma unroll
+    for (int m = 0; m < thread_m_dim; m++) {
+#pragma unroll
+      for (int n = 0; n < thread_n_dim; n++) {
+        int m_idx = threadIdx.z + m * block_z;
+        int n_idx = threadIdx.y + n * block_y;
+        if (m_idx + 1 < bM) { q_s[shared_memory_offset<bK, bN>(m_idx + 1, n_idx)] = reg[m * thread_n_dim + n]; }
+      }
+    }
+
+    j -= 1;
+  }
+}
+
+void set_max_shared_bytes(const void *func)
+{
+  // Set such that this kernel can use the maximum shared memory available.
+  cudaFuncSetAttribute(func, cudaFuncAttributePreferredSharedMemoryCarveout, (int)cudaSharedmemCarveoutMaxShared);
+  int max_shared_bytes;
+  cudaDeviceGetAttribute(&max_shared_bytes, cudaDevAttrMaxSharedMemoryPerBlockOptin, 0);
+  cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize, max_shared_bytes);
+}
+
+template <int bM, class F>
+void launch_new_kernel(F *q, const F *hh, const F *hh_tau, const int nev, const int nb, const int ldq, const int ncols)
+{
+#ifdef USE_MMA
+  // This is set such that shared memory bank conflicts are minimized.
+  constexpr int block_y = bM < 64 ? 8 : 4;
+  constexpr int block_z = bM < 64 ? 4 : 8;
+#else
+  constexpr int block_y = 8;
+  constexpr int block_z = 4;
+#endif
+  constexpr int bN = 8;
+  auto kernel = compute_hh_trafo_gpu<double, bM, bN, block_y, block_z>;
+  set_max_shared_bytes((const void *)kernel);
+#ifdef USE_MMA
+  int shared_bytes = (bM + shared_memory_bytes(bM, bN) + bN + 1) * sizeof(F);
+#else
+  int shared_bytes = (bM + shared_memory_bytes(bM, bN) + 1) * sizeof(F);
+#endif
+  int grid_y = (nev + bN - 1) / bN;
+  kernel<<<dim3(1, grid_y, 1), dim3(1, block_y, block_z), shared_bytes>>>(q, hh, hh_tau, nev, nb, ldq, ncols);
+}
+
 /*
 Name here : Name in paper
 q         : X
@@ -225,42 +413,105 @@ ncols     : N_R (==n+b-1)
 */
 extern "C" void compute_hh_gpu_kernel(double *q, const double *hh, const double *hh_tau, const int nev, const int nb, const int ldq, const int ncols)
 {
+
+    cudaEvent_t new_start;
+    cudaEvent_t new_stop;
+
+    cudaEvent_t old_start;
+    cudaEvent_t old_stop;
+
+    cudaEventCreate(&new_start);
+    cudaEventCreate(&new_stop);
+
+    cudaEventCreate(&old_start);
+    cudaEventCreate(&old_stop);
+
+    // Create duplicate device buffers for the old kernel.
+    double *q_x;
+    cudaMalloc(&q_x, (ncols + nb - 1) * ldq * sizeof(double));
+    cudaMemcpy(q_x, q, (ncols + nb - 1) * ldq, cudaMemcpyDeviceToDevice);
+    double *hh_x;
+    cudaMalloc(&hh_x, ncols * nb * sizeof(double));
+    cudaMemcpy(hh_x, hh, ncols * nb, cudaMemcpyDeviceToDevice);
+    double *hh_tau_x;
+    cudaMalloc(&hh_tau_x, ncols * sizeof(double));
+    cudaMemcpy(hh_tau_x, hh_tau, ncols, cudaMemcpyDeviceToDevice);
+
+    // Run the old kernel
+    cudaEventRecord(old_start);
+
     switch (nb)
     {
-    case 1024:
-        compute_hh_trafo_kernel_real<double, 1024><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 1024:
+        compute_hh_trafo_kernel_real<double, 1024><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 512:
-        compute_hh_trafo_kernel_real<double, 512><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 512:
+        compute_hh_trafo_kernel_real<double, 512><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 256:
-        compute_hh_trafo_kernel_real<double, 256><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 256:
+        compute_hh_trafo_kernel_real<double, 256><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 128:
-        compute_hh_trafo_kernel_real<double, 128><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 128:
+        compute_hh_trafo_kernel_real<double, 128><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 64:
-        compute_hh_trafo_kernel_real<double, 64><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 64:
+        compute_hh_trafo_kernel_real<double, 64><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 32:
-        compute_hh_trafo_kernel_real<double, 32><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 32:
+        compute_hh_trafo_kernel_real<double, 32><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 16:
-        compute_hh_trafo_kernel_real<double, 16><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 16:
+        compute_hh_trafo_kernel_real<double, 16><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 8:
-        compute_hh_trafo_kernel_real<double, 8><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 8:
+        compute_hh_trafo_kernel_real<double, 8><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 4:
-        compute_hh_trafo_kernel_real<double, 4><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 4:
+        compute_hh_trafo_kernel_real<double, 4><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 2:
-        compute_hh_trafo_kernel_real<double, 2><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 2:
+        compute_hh_trafo_kernel_real<double, 2><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
-    case 1:
-        compute_hh_trafo_kernel_real<double, 1><<<nev, nb>>>(q, hh, hh_tau, nb, ldq, ncols);
+      case 1:
+        compute_hh_trafo_kernel_real<double, 1><<<nev, nb>>>(q_x, hh_x, hh_tau_x, nb, ldq, ncols);
         break;
+      default: printf("Unsupported nb = %d", nb);
     }
+
+    cudaEventRecord(old_stop);
+    cudaEventSynchronize(old_stop);
+
+    cudaFree(q_x);
+    cudaFree(hh_x);
+    cudaFree(hh_tau_x);
+
+    // Run the new kernel
+    cudaEventRecord(new_start);
+
+    switch (nb) {
+      case 1024: launch_new_kernel<1024>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case  512: launch_new_kernel< 512>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case  256: launch_new_kernel< 256>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case  128: launch_new_kernel< 128>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case   64: launch_new_kernel<  64>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case   32: launch_new_kernel<  32>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case   16: launch_new_kernel<  16>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      case    8: launch_new_kernel<   8>(q, hh, hh_tau, nev, nb, ldq, ncols); break;
+      default: printf("Unsupported nb = %d", nb);
+    }
+
+    cudaEventRecord(new_stop);
+    cudaEventSynchronize(new_stop);
+
+    // Collect time and perf
+    float old_time;
+    float new_time;
+    cudaEventElapsedTime(&new_time, new_start, new_stop);
+    cudaEventElapsedTime(&old_time, old_start, old_stop);
+    double ops = nev * nb * (2.0 + 3.0) * ncols;
+    double bytes = ((nb * ncols) + (nb + ncols - 1) * nev * 2.0) * sizeof(double);
+    printf("Old kernel took %8.4f ms, GFLOPS = %6.1f, GBS = %6.1f\n", old_time, ops / (old_time * 1e-3) / 1e+9, bytes / (old_time * 1e-3) / 1e+9);
+    printf("New kernel took %8.4f ms, GFLOPS = %6.1f, GBS = %6.1f\n", new_time, ops / (new_time * 1e-3) / 1e+9, bytes / (new_time * 1e-3) / 1e+9);
 
     cudaError_t err = cudaGetLastError();
 

--- a/src/compute_hh_wrapper.f90
+++ b/src/compute_hh_wrapper.f90
@@ -1,3 +1,28 @@
+! ******
+!
+! The MIT License (MIT)
+!
+! Copyright (c) 2019 Victor Yu
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy of
+! this software and associated documentation files (the "Software"), to deal in
+! the Software without restriction, including without limitation the rights to
+! use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+! the Software, and to permit persons to whom the Software is furnished to do so,
+! subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in all
+! copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+! FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+! COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+! IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+!
+! ******
+
 module compute_hh_wrapper
 
   use iso_c_binding, only: c_double,c_intptr_t

--- a/src/cuda_c_interface.cu
+++ b/src/cuda_c_interface.cu
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Victor Yu
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/src/cuda_f_interface.f90
+++ b/src/cuda_f_interface.f90
@@ -1,3 +1,28 @@
+! ******
+!
+! The MIT License (MIT)
+!
+! Copyright (c) 2019 Victor Yu
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy of
+! this software and associated documentation files (the "Software"), to deal in
+! the Software without restriction, including without limitation the rights to
+! use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+! the Software, and to permit persons to whom the Software is furnished to do so,
+! subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in all
+! copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+! FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+! COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+! IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+! CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+!
+! ******
+
 module cuda_f_interface
 
   implicit none

--- a/src/mma_m8n8k4_fp64_sm80.cuh
+++ b/src/mma_m8n8k4_fp64_sm80.cuh
@@ -1,0 +1,162 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 NVIDIA CORPORATION
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+constexpr int pad = 0;
+
+// How big a tile each warp possess?
+constexpr int WARP_M = 1;
+constexpr int WARP_N = 1;
+
+// We use the m8n8k4 DMMA instruction
+constexpr int INST_M = 8;
+constexpr int INST_N = 8;
+constexpr int INST_K = 4;
+
+constexpr int MMA_M = INST_M * WARP_M;
+constexpr int MMA_N = INST_N * WARP_N;
+constexpr int MMA_K = INST_K;
+
+template<int bK, int bN>
+__device__ inline int shared_memory_offset(int k, int n) {
+  // Shared memory layout for MMA version. The pad of `4` is used to get rid shared memory
+  // bank conflicts.
+  return k + (bK + 4) * n;
+}
+
+__device__ inline constexpr int shared_memory_bytes(int bK, int bN) {
+  // Shared memory size for the bM by bK matrix. Version for the MMA.
+  return bN * (bK + 4);
+}
+
+struct WarpRegisterMapping {
+  int lane_id;
+  int group_id;
+  int thread_id_in_group;
+
+  __device__ WarpRegisterMapping(int thread_id) :
+    lane_id(thread_id & 31),
+    group_id(lane_id >> 2),
+    thread_id_in_group(lane_id & 3)
+  {
+  }
+};
+
+struct MmaOperandA {
+
+  using reg_type = double;
+  reg_type reg = 0;
+
+  __device__ inline void construct_sum(void *smem, int tile_k, const WarpRegisterMapping &wrm)
+  { // Assuming col major smem layout
+
+    reg_type *A = reinterpret_cast<reg_type *>(smem);
+    int k = tile_k * MMA_K + wrm.thread_id_in_group;
+    int m = wrm.group_id;
+    reg = m == 0 ? A[k] : 0;
+  }
+
+};
+
+struct MmaOperandB {
+
+  using reg_type = double;
+  reg_type reg = 0;
+
+  template <int bK, int bN> __device__ inline void load(void *smem, int tile_k, int tile_n, const WarpRegisterMapping &wrm)
+  {
+    reg_type *B = reinterpret_cast<reg_type *>(smem);
+    int k = tile_k * MMA_K + wrm.thread_id_in_group;
+    int n = tile_n * MMA_N + wrm.group_id;
+    reg = B[shared_memory_offset<bK, bN>(k, n)];
+  }
+};
+
+struct MmaOperandC {
+
+  using reg_type = double;
+  reg_type reg[2];
+
+  __device__ MmaOperandC()
+  {
+#pragma unroll
+    for (int i = 0; i < WARP_M * WARP_N * 2; i++) { reg[i] = 0; }
+  }
+
+  __device__ void store_sum(void *smem, int tile_n, const WarpRegisterMapping &wrm)
+  {
+    reg_type *C = reinterpret_cast<reg_type *>(smem);
+    const int m = wrm.group_id;
+    const int n = tile_n * MMA_N + wrm.thread_id_in_group * 2;
+
+    if (m == 0) {
+      C[n + 0] = reg[0];
+      C[n + 1] = reg[1];
+    }
+  }
+};
+
+template <int bK, int bN, int total_warp> // bM == 1
+__device__ void sum(double *smem_a, double *smem_b, double *smem_c) {
+
+  constexpr int tile_row_dim = 1;          // number of tiles in the col dimension
+  constexpr int tile_col_dim = bN / MMA_N; // number of tiles in the row dimension
+  constexpr int tile_acc_dim = bK / MMA_K; // number of tiles in the acc dimension
+
+	constexpr int total_tile = tile_row_dim * tile_col_dim;
+	constexpr int warp_cycle = total_tile / total_warp;
+
+	static_assert(total_tile % total_warp == 0, "Total number of tiles should be divisible by the number of warps.");
+
+	const int thread_id = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
+	const int warp_id = thread_id / 32;
+
+	WarpRegisterMapping wrm(thread_id);
+
+#pragma unroll
+	for (int c = 0; c < warp_cycle; c++) {
+
+		MmaOperandC op_c;
+
+		// The logical warp assigned to each part of the matrix.
+		int logical_warp_index = warp_id * warp_cycle + c;
+		int tile_n = logical_warp_index;
+
+#pragma unroll
+		for (int tile_k = 0; tile_k < tile_acc_dim; tile_k++) {
+			MmaOperandA op_a;
+			op_a.construct_sum(smem_a, tile_k, wrm);
+
+			MmaOperandB op_b;
+			op_b.template load<bK, bN>(smem_b, tile_k, tile_n, wrm);
+
+			asm volatile("mma.sync.aligned.m8n8k4.row.col.f64.f64.f64.f64 {%0,%1}, {%2}, {%3}, {%0,%1};"
+					: "+d"(op_c.reg[0]), "+d"(op_c.reg[1]) : "d"(op_a.reg), "d"(op_b.reg)
+					);
+		}
+
+		op_c.store_sum(smem_c, tile_n * MMA_N, wrm);
+	}
+
+}


### PR DESCRIPTION
This PR adds a new HH transformation kernel that is more performant for large `nev`. The new kernel works with and without (the `USE_MMA` macro) the double precision tensor cores available on the A100 GPUs, with which the kernel gives a better performance. The following table gives a summary of the speed up numbers (larger the better) of both versions over the original kernel on an A100 GPU (SM @ 1410MHz, Memory @ 1215MHz): generally the new kernel is faster with larger `nev` but is slower with smaller `nev`.

nb | nev | MMA/Old | No MMA/Old
:-: | :-: | :-: | :-:
8 | 1280 | 0.73 | 0.61
8 | 2560 | 0.64 | 0.56
8 | 5120 | 1.19 | 1.05
8 | 10240 | 1.91 | 1.71
8 | 20480 | 3.46 | 3.21
16 | 1280 | 0.66 | 0.49
16 | 2560 | 0.59 | 0.46
16 | 5120 | 1.09 | 0.88
16 | 10240 | 1.76 | 1.44
16 | 20480 | 3.14 | 2.66
32 | 1280 | 0.61 | 0.36
32 | 2560 | 0.56 | 0.36
32 | 5120 | 1.08 | 0.71
32 | 10240 | 1.58 | 1.19
32 | 20480 | 2.41 | 1.99

The new kernel reuses the HH vector data by having multiple eigenvectors within the same CUDA thread block, thus changing the kernel from L2 cache bandwidth bound to shared memory bandwidth bound. The use of the DMMA instructions help reducing the pressure on shared memory. However, if there is not enough eigenvectors the GPU is not fed with enough thread blocks.

In addition the interface of the app is added with the option to specify `nev` and helper functions to print out performance metrics for the original and new kernels.